### PR TITLE
Additional cleanup

### DIFF
--- a/playbooks/openshift_setup.yml
+++ b/playbooks/openshift_setup.yml
@@ -75,6 +75,9 @@
       openshift_node_labels:
         region: "{{ hostvars[item]['ec2_tag_node-region'] }}"
         zone: default
+      openshift_node_kubelet_args:
+        max-pods:
+        - 100
     with_items: node_hosts
 
 # Configure the instances

--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -91,13 +91,6 @@
 
   - command: oc project default
 
-  - name: Fix node labels
-    command: oc label --overwrite nodes {{ hostvars[item].openshift.common.hostname }} region={{ hostvars[item].openshift_node_labels.region }} zone={{ hostvars[item].openshift_node_labels.zone }}
-    with_items: groups.oo_nodes_to_config
-
-  - name: Unschedule master
-    command: oadm manage-node --selector="region=master" --schedulable=false
-
   - name: Set nodeselector for the default project to be region=infra
     shell: "oc get namespace default -o yaml  | sed -e '/  annotations:/a\\    openshift.io/node-selector: region=infra' | oc replace -f -"
 

--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -24,11 +24,8 @@
       name: "{{ demo_hosts.0 }}"
       groups: oo_demo_nodes
 
-- name: Verify hosts in the infra region have core ansible facts
-  hosts: oo_infra_nodes
-
-- name: Verify hosts in the demo region have core ansible facts
-  hosts: oo_demo_nodes
+- name: Verify node host groups have core ansible facts
+  hosts: oo_infra_nodes:oo_demo_nodes
 
 - name: Node post config
   hosts: oo_nodes_to_config
@@ -63,16 +60,6 @@
       line: prepend domain-name-servers {{ hostvars[groups.oo_first_master.0].openshift.dns.ip }}
       state: present
       create: yes
-
-  # Temporary workaround until openshift-ansible supports setting
-  # kubeletArguments directly
-  - name: Set kubeletArguments
-    lineinfile:
-      dest: /etc/openshift/node/node-config.yaml
-      state: present
-      regexp: '^kubeletArguments:'
-      line: 'kubeletArguments: { max-pods: ["100"] }'
-    notify: restart openshift-node
 
   - name: pre-pull images
     command: "docker pull {{ item }}"

--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -81,8 +81,6 @@
     users:
     - name: demo
       project: demo
-    - name: hexboard
-      project: hexboard
     - name: "{{ prime_user }}"
       project: "{{ prime_namespace }}"
     default_context: '{{ "default/" ~ (hostvars[groups.oo_first_master.0].openshift.common.hostname | regex_replace("\.", "-")) ~ ":" ~ hostvars[groups.oo_first_master.0].openshift.master.api_port ~ "/system:admin" }}'

--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -10,10 +10,25 @@
   tasks:
   - add_host:
       name: "{{ infra_hosts.0 }}"
-      groups: oo_first_infra_node
+      groups: oo_infra_nodes
+
+- name: Create group for demo hosts in this env only
+  hosts: localhost
+  gather_facts: no
+  connection: local
+  sudo: no
+  vars:
+    demo_hosts: "{{ groups['tag_node-region_demo'] | intersect(groups['tag_env_' ~ cluster_id]) }}"
+  tasks:
+  - add_host:
+      name: "{{ demo_hosts.0 }}"
+      groups: oo_demo_nodes
 
 - name: Verify hosts in the infra region have core ansible facts
-  hosts: oo_first_infra_node
+  hosts: oo_infra_nodes
+
+- name: Verify hosts in the demo region have core ansible facts
+  hosts: oo_demo_nodes
 
 - name: Node post config
   hosts: oo_nodes_to_config
@@ -137,7 +152,7 @@
     when: registry_out | failed
 
   - name: Set registry GOMAXPROCS
-    command: oc env dc/docker-registry GOMAXPROCS={{ hostvars[groups.oo_first_infra_node.0].ansible_processor_cores }}
+    command: oc env dc/docker-registry GOMAXPROCS={{ hostvars[groups.oo_infra_nodes.0].ansible_processor_cores }}
 
   - name: Wait for 60 seconds for registry to re-deploy
     pause: minutes=1
@@ -201,14 +216,13 @@
       service: name=openshift-master state=restarted
 
 - name: Node post config
-  hosts: oo_nodes_to_config
+  hosts: oo_demo_nodes[0]
   vars_files:
   - ../vars.yml
   vars:
     registry_ip: "{{ hostvars[groups.oo_first_master.0].registry_ip }}"
     registry_port: "{{ hostvars[groups.oo_first_master.0].registry_port }}"
     default_context: '{{ "default/" ~ (hostvars[groups.oo_first_master.0].openshift.common.hostname | regex_replace("\.", "-")) ~ ":" ~ hostvars[groups.oo_first_master.0].openshift.master.api_port ~ "/system:admin" }}'
-  serial: 1
   tasks:
   - command: docker pull {{ item.prefix }}/{{ item.image }}:{{ item.tag }}
     with_items: prime_images


### PR DESCRIPTION
- Remove workarounds that are now fixed in upstream openshift-ansible
- Set kubletArguments using openshift-ansible instead of using the workaround
- Prime the registry only from the first node in the demo region
- Remove unused hexboard user/project
