### PR TITLE
set the https api_port and console_port via the CLI

### DIFF
--- a/playbooks/openshift_setup.yml
+++ b/playbooks/openshift_setup.yml
@@ -7,7 +7,7 @@
   tasks:
   - fail:
       msg: required values not set
-    when: cluster_id is not defined or ec2_region is not defined or ec2_image is not defined or ec2_keypair is not defined or ec2_master_instance_type is not defined or ec2_infra_instance_type is not defined or ec2_node_instance_type is not defined or r53_zone is not defined or r53_host_zone is not defined or r53_wildcard_zone is not defined or num_app_nodes is not defined or hexboard_size is not defined or rhsm_user is not defined or rhsm_pass is not defined
+    when: cluster_id is not defined or ec2_region is not defined or ec2_image is not defined or ec2_keypair is not defined or ec2_master_instance_type is not defined or ec2_infra_instance_type is not defined or ec2_node_instance_type is not defined or r53_zone is not defined or r53_host_zone is not defined or r53_wildcard_zone is not defined or num_app_nodes is not defined or hexboard_size is not defined or api_port is not defined or console_port is not defined or rhsm_user is not defined or rhsm_pass is not defined
 
 # create VPC configuration
 - include: util_playbooks/create_vpc.yml
@@ -58,6 +58,8 @@
       openshift_deployment_type: "{{ deployment_type }}"
       openshift_master_access_token_max_seconds: 2419200
       openshift_master_identity_providers: "{{ identity_providers }}"
+      openshift_master_api_port: "{{ api_port }}"
+      openshift_master_console_port: "{{ console_port }}"
       osm_cluster_network_cidr: 10.0.0.0/8
       osm_host_subnet_length: 16
       osm_default_subdomain: "{{ r53_wildcard_zone }}"

--- a/run.py
+++ b/run.py
@@ -35,6 +35,10 @@ env_sizes = {'tiny': 1,
               help='route53 hosted zone (must be pre-configured)')
 @click.option('--app-dns-prefix', default='apps', help='application dns prefix',
               show_default=True)
+@click.option('--console-port', default='8443', type=int, help='openshift web console port',
+              show_default=True)
+@click.option('--api-port', default='8443', type=int, help='openshift api port',
+              show_default=True)
 @click.option('--rhsm-user', prompt=True, help='Red Hat Subscription Management User')
 @click.option('--rhsm-pass', prompt=True, hide_input=True,
               help='Red Hat Subscription Management Password')
@@ -53,10 +57,10 @@ env_sizes = {'tiny': 1,
 def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
                     master_instance_type=None, node_instance_type=None,
                     infra_instance_type=None, keypair=None, r53_zone=None,
-                    cluster_id=None, app_dns_prefix=None, rhsm_user=None,
-                    rhsm_pass=None, skip_subscription_management=False,
-                    run_smoke_tests=False, num_smoke_test_users=None,
-                    default_password=None, verbose=0):
+                    cluster_id=None, app_dns_prefix=None, api_port=8443, 
+                    console_port=8443, rhsm_user=None, rhsm_pass=None, 
+                    skip_subscription_management=False, run_smoke_tests=False, 
+                    num_smoke_test_users=None, default_password=None, verbose=0):
     click.echo('Configured values:')
     click.echo('\tcluster_id: %s' % cluster_id)
     click.echo('\tenv_size: %s' % env_size)
@@ -68,6 +72,8 @@ def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
     click.echo('\tkeypair: %s' % keypair)
     click.echo('\tr53_zone: %s' % r53_zone)
     click.echo('\tapp_dns_prefix: %s' % app_dns_prefix)
+    click.echo('\tmaster api port: %s' % api_port)
+    click.echo('\tmaster web console port: %s' % console_port)
     click.echo('\trhsm_user: %s' % rhsm_user)
     click.echo('\trhsm_pass: *******')
 
@@ -88,7 +94,7 @@ def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
     command='inventory/aws/hosts/ec2.py --refresh-cache'
     os.system(command)
 
-    command='ansible-playbook -i inventory/aws/hosts -e \'cluster_id=%s ec2_region=%s ec2_image=%s ec2_keypair=%s ec2_master_instance_type=%s ec2_infra_instance_type=%s ec2_node_instance_type=%s r53_zone=%s r53_host_zone=%s r53_wildcard_zone=%s num_app_nodes=%s hexboard_size=%s rhsm_user=%s rhsm_pass=%s skip_subscription_management=%s run_smoke_tests=%s num_smoke_test_users=%s default_password=%s\' playbooks/openshift_setup.yml' % (cluster_id, region, ami, keypair, master_instance_type, infra_instance_type, node_instance_type, r53_zone, host_zone, wildcard_zone, env_sizes[env_size], env_size, rhsm_user, rhsm_pass, skip_subscription_management, run_smoke_tests, num_smoke_test_users, default_password)
+    command='ansible-playbook -i inventory/aws/hosts -e \'cluster_id=%s ec2_region=%s ec2_image=%s ec2_keypair=%s ec2_master_instance_type=%s ec2_infra_instance_type=%s ec2_node_instance_type=%s r53_zone=%s r53_host_zone=%s r53_wildcard_zone=%s num_app_nodes=%s hexboard_size=%s api_port=%s console_port=%s rhsm_user=%s rhsm_pass=%s skip_subscription_management=%s run_smoke_tests=%s num_smoke_test_users=%s default_password=%s\' playbooks/openshift_setup.yml' % (cluster_id, region, ami, keypair, master_instance_type, infra_instance_type, node_instance_type, r53_zone, host_zone, wildcard_zone, env_sizes[env_size], env_size, api_port, console_port, rhsm_user, rhsm_pass, skip_subscription_management, run_smoke_tests, num_smoke_test_users, default_password)
 
     if verbose > 0:
         command += " -" + "".join(['v']*verbose)


### PR DESCRIPTION
By default, the playbook will continue to expose the API and web console on `8443`.

You can also supply the following flags to `run.py` to move these services to a standard SSL port: `--console-port 443` `--api-port 443`
