### PR TITLE
Describe environment size (node) options in --help

### DIFF
--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -186,6 +186,7 @@
     template:
       dest: /tmp/registry.sh
       src: ../templates/registry.sh.j2
+      mode: 0755
 
   - shell: /tmp/registry.sh
     register: registry_uri_out

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ env_sizes = {'tiny': 1,
 @click.option('--cluster-id', default='demo', show_default=True,
               help='cluster identifier (used for assigning ec2 tags, naming security groups, and is used as a subdomain of the r53-zone for environment dns entries')
 @click.option('--env-size', type=click.Choice(env_sizes),
-              default='tiny', help='Environment size',
+              default='tiny', help='environment size (nodes tiny=1, xsmall=2, small=3, medium=5, large=10, xlarge=20)',
               show_default=True)
 @click.option('--region', default='us-east-1', help='ec2 region',
               show_default=True)

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ env_sizes = {'tiny': 1,
 @click.option('--cluster-id', default='demo', show_default=True,
               help='cluster identifier (used for assigning ec2 tags, naming security groups, and is used as a subdomain of the r53-zone for environment dns entries')
 @click.option('--env-size', type=click.Choice(env_sizes),
-              default='tiny', help='environment size (nodes tiny=1, xsmall=2, small=3, medium=5, large=10, xlarge=20)',
+              default='tiny', help='Environment size (nodes tiny=1, xsmall=2, small=3, medium=5, large=10, xlarge=20)',
               show_default=True)
 @click.option('--region', default='us-east-1', help='ec2 region',
               show_default=True)


### PR DESCRIPTION
It isn't clear what changes with environment size options unless  you have a look at run.py, adding description in --help to be more clear for users.

Updated permissions for registry.sh
