### PR TITLE
Registry perms fix

### DIFF
--- a/playbooks/templates/registry.sh.j2
+++ b/playbooks/templates/registry.sh.j2
@@ -1,1 +1,2 @@
+#!/bin/bash
 /bin/oc get service docker-registry -t {{"'{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}'"}}

--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -186,8 +186,9 @@
     template:
       dest: /tmp/registry.sh
       src: ../templates/registry.sh.j2
+      mode: 0755
 
-  - shell: /tmp/registry.sh
+  - command: /tmp/registry.sh
     register: registry_uri_out
 
   - set_fact:


### PR DESCRIPTION
Fixed a couple of things that were still broken. Now the registry script includes a shebang, has the right permissions, and is called via Ansible's "command" module.
