### PR TITLE
tweak for subscription names which was resulting in failed registrations against real subscriptions

### DIFF
--- a/playbooks/util_playbooks/register_host.yml
+++ b/playbooks/util_playbooks/register_host.yml
@@ -37,5 +37,5 @@
       username: "{{ rhsm_user }}"
       password: "{{ rhsm_pass }}"
       state: present
-      pool: "^(60 Day Supported OpenShift Enterprise|OpenShift Enterprise Premium|Employee)"
+      pool: "^(60 Day Supported OpenShift Enterprise|OpenShift Enterprise, Standard|OpenShift Enterprise, Premium|Employee)"
     when: not (skip_subscription_management | bool)


### PR DESCRIPTION
the name we had didn't match because of the comma and whatnot, so this appears to be a fix for it. Wait a little bit before merging as this is running right now.
