### PR TITLE
fixing broken reference to inventory hostvars dns_ip

### DIFF
--- a/playbooks/util_playbooks/post_setup.yml
+++ b/playbooks/util_playbooks/post_setup.yml
@@ -52,12 +52,12 @@
   - lineinfile:
       dest: /etc/resolv.conf
       insertbefore: ^nameserver 172.*$
-      line: nameserver {{ hostvars[groups.oo_first_master.0].openshift.dns.ip }}
+      line: nameserver {{ hostvars[groups.oo_first_master.0].openshift.common.dns_ip }}
       state: present
 
   - lineinfile:
       dest: /etc/dhcp/dhclient-eth0.conf
-      line: prepend domain-name-servers {{ hostvars[groups.oo_first_master.0].openshift.dns.ip }}
+      line: prepend domain-name-servers {{ hostvars[groups.oo_first_master.0].openshift.common.dns_ip }}
       state: present
       create: yes
 


### PR DESCRIPTION
Fix for error:

```
fatal: [ec2-4-6-8-9.us-west-1.compute.amazonaws.com] => One or more undefined variables: 'dict object' has no attribute 'dns'
```
