### PR TITLE
Enable use of PEM/SSL certificates with the yum repos

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,5 +16,5 @@ become = True
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=900s
-control_path = %(directory)s/%%C
+control_path = %(directory)s/%%h-%%r
 #pipelining = True

--- a/playbooks/templates/aos.repo.j2
+++ b/playbooks/templates/aos.repo.j2
@@ -1,0 +1,9 @@
+[aos]
+name=Prerelease version of Atomic Enterprise Platform and OpenShift Enterprise RPMs
+baseurl={{ aos_repo | default('https://mirror.openshift.com/enterprise/enterprise-3.1.1.6/RH7-RHAOS-3.1/x86_64/os/Packages/') }}
+failovermethod=priority
+enabled=1
+gpgcheck=0
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/playbooks/templates/aos.repo.j2
+++ b/playbooks/templates/aos.repo.j2
@@ -1,6 +1,6 @@
 [aos]
 name=Prerelease version of Atomic Enterprise Platform and OpenShift Enterprise RPMs
-baseurl={{ aos_repo | default('https://mirror.openshift.com/enterprise/enterprise-3.1.1.6/RH7-RHAOS-3.1/x86_64/os/Packages/') }}
+baseurl={{ aos_repo | default('https://mirror.openshift.com/enterprise/enterprise-3.1.1.6/RH7-RHAOS-3.1/x86_64/os') }}
 failovermethod=priority
 enabled=1
 gpgcheck=0

--- a/playbooks/util_playbooks/host_repos.yml
+++ b/playbooks/util_playbooks/host_repos.yml
@@ -25,7 +25,6 @@
   tasks:
   - name: Enable rhui extras channel
     command: yum-config-manager --enable rhui-REGION-rhel-server-extras
-    when: register_result | changed
 
   - name: Create AOS yum repository configuration
     template:

--- a/playbooks/util_playbooks/host_repos.yml
+++ b/playbooks/util_playbooks/host_repos.yml
@@ -25,6 +25,7 @@
   tasks:
   - name: Enable rhui extras channel
     command: yum-config-manager --enable rhui-REGION-rhel-server-extras
+    when: use_certificate_repos
 
   - name: Create AOS yum repository configuration
     template:

--- a/playbooks/util_playbooks/host_repos.yml
+++ b/playbooks/util_playbooks/host_repos.yml
@@ -23,21 +23,26 @@
 - name: Repository configuration
   hosts: oo_hosts_to_register
   tasks:
-  - name: Configure OSE repository
-    copy:
-      src: ../files/ose3.repo
-      dest: /etc/yum.repos.d/ose3.repo
-      mode: 0644
-      owner: root
-      group: root
-    when: skip_subscription_management | bool
-
   - name: Enable rhui extras channel
     command: yum-config-manager --enable rhui-REGION-rhel-server-extras
-    when: skip_subscription_management | bool
+    when: register_result | changed
 
-  - name: Update current package set
-    yum:
-      name: '*'
-      state: latest
-    when: skip_subscription_management | bool
+  - name: Create AOS yum repository configuration
+    template:
+      src: ../templates/aos.repo.j2
+      dest: /etc/yum.repos.d/aos.repo
+      mode: 644
+    when: use_certificate_repos
+
+  - name: Copy Atomic OpenShift yum repository certificate
+    copy:
+      src: '{{ certificate_file }}'
+      dest: /var/lib/yum/
+    when: use_certificate_repos
+  
+  - name: Copy Atomic OpenShift yum repository key
+    copy:
+      src: '{{ certificate_key }}'
+      dest: /var/lib/yum/
+    when: use_certificate_repos
+

--- a/run.py
+++ b/run.py
@@ -46,6 +46,12 @@ env_sizes = {'tiny': 1,
               help='Red Hat Subscription Management Password')
 @click.option('--skip-subscription-management', is_flag=True,
               help='Skip subscription management steps')
+@click.option('--use-certificate-repos', is_flag=True,
+              help='Uses certificate-based yum repositories for the AOS content. Requires providing paths to local certificate key and pem files.')
+@click.option('--certificate-file', help='Certificate file for the yum repository',
+              show_default=True)
+@click.option('--certificate-key', help='Certificate key for the yum repository',
+              show_default=True)
 @click.option('--no-confirm', is_flag=True,
               help='Skip confirmation prompt')
 @click.option('--run-smoke-tests', is_flag=True, help='Run workshop smoke tests')
@@ -63,7 +69,11 @@ def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
                     cluster_id=None, app_dns_prefix=None,
                     deployment_type=None, console_port=443, api_port=443,
                     rhsm_user=None, rhsm_pass=None,
-                    skip_subscription_management=False, run_smoke_tests=False,
+                    skip_subscription_management=False, 
+                    certificate_file=None,
+                    certificate_key=None,
+                    use_certificate_repos=False,
+                    run_smoke_tests=False,
                     num_smoke_test_users=None, run_only_smoke_tests=False,
                     default_password=None, verbose=0):
     click.echo('Configured values:')
@@ -89,6 +99,8 @@ def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
     click.echo('Host DNS entries will be created under the %s domain' % host_zone)
     click.echo('Application wildcard zone for this env will be %s' % wildcard_zone)
 
+    if use_certificate_repos:
+        click.echo('Certificate file %s and certificate key %s will be used for the yum repos' % (certificate_file, certificate_key))
 
     if run_smoke_tests or run_only_smoke_tests:
         click.echo('Smoke tests will be run following environment creation with %s users with password %s' % (num_smoke_test_users, default_password))
@@ -112,7 +124,7 @@ def launch_demo_env(env_size=None, region=None, ami=None, no_confirm=False,
     if run_only_smoke_tests:
         playbook = 'playbooks/projects_setup.yml'
 
-    command='ansible-playbook -i inventory/aws/hosts -e \'cluster_id=%s ec2_region=%s ec2_image=%s ec2_keypair=%s ec2_master_instance_type=%s ec2_infra_instance_type=%s ec2_node_instance_type=%s r53_zone=%s r53_host_zone=%s r53_wildcard_zone=%s num_app_nodes=%s hexboard_size=%s deployment_type=%s api_port=%s console_port=%s rhsm_user=%s rhsm_pass=%s skip_subscription_management=%s run_smoke_tests=%s run_only_smoke_tests=%s num_smoke_test_users=%s default_password=%s\' %s' % (cluster_id, region, ami, keypair, master_instance_type, infra_instance_type, node_instance_type, r53_zone, host_zone, wildcard_zone, env_sizes[env_size], env_size, deployment_type, api_port, console_port, rhsm_user, rhsm_pass, skip_subscription_management, run_smoke_tests, run_only_smoke_tests, num_smoke_test_users, default_password, playbook)
+    command='ansible-playbook -i inventory/aws/hosts -e \'cluster_id=%s ec2_region=%s ec2_image=%s ec2_keypair=%s ec2_master_instance_type=%s ec2_infra_instance_type=%s ec2_node_instance_type=%s r53_zone=%s r53_host_zone=%s r53_wildcard_zone=%s num_app_nodes=%s hexboard_size=%s deployment_type=%s api_port=%s console_port=%s rhsm_user=%s rhsm_pass=%s skip_subscription_management=%s use_certificate_repos=%s certificate_file=%s certificate_key=%s run_smoke_tests=%s run_only_smoke_tests=%s num_smoke_test_users=%s default_password=%s\' %s' % (cluster_id, region, ami, keypair, master_instance_type, infra_instance_type, node_instance_type, r53_zone, host_zone, wildcard_zone, env_sizes[env_size], env_size, deployment_type, api_port, console_port, rhsm_user, rhsm_pass, skip_subscription_management, use_certificate_repos, certificate_file, certificate_key, run_smoke_tests, run_only_smoke_tests, num_smoke_test_users, default_password, playbook)
 
     if verbose > 0:
         command += " -" + "".join(['v']*verbose)


### PR DESCRIPTION
This PR adds the ability for specifying PEM certificate files for use with yum repositories so that subscription management can be skipped. It adds several options to `run.py`:
1. `--use-certificate-repos`: sets the boolean
2. `--certificate-file`: specifies a path to a local file that will be used remotely as `client-cert.pem`
3. `--certificate-key`: specifies a path to a local file that will be used remotely as `client-key.pem`

A change was introduced by @juhoffma to fix `ControlPath` for El Capitan/MacOS which unfortunately breaks things on Linux, so this reverts that change back. I don't know how this is going to be resolved.

This was tested using both the new certificate method as well as using the existing RHSM method successfully.
