### PR TITLE
Update README.md with additional IAM policy information

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The scripts can create workshop users, too.
 ## Prerequisites
 In order to use these scripts, you will need to set a few things up.
 
-- An AWS account with the following permissions:
+- An AWS IAM account with the following permissions (custom inline policy):
 ```
 {
     "Version": "2012-10-17",
@@ -34,7 +34,12 @@ In order to use these scripts, you will need to set a few things up.
             "Effect": "Allow",
             "Action": [
                 "cloudformation:*",
-                "iam:*"
+                "iam:*",
+                "route53:*",
+                "elasticloadbalancing:*",
+                "ec2:*",
+                "cloudwatch:*",
+                "autoscaling:*"
             ],
             "Resource": [
                 "*"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ The scripts can create workshop users, too.
 ## Prerequisites
 In order to use these scripts, you will need to set a few things up.
 
-- An AWS IAM account with the following permissions (custom inline policy):
+- An AWS IAM account with the following permissions:
+  - Policies can be defined for Users, Groups or Roles
+  - Navigate to: AWS Dashboard -> Identity & Access Management -> Select Users or Groups or Roles -> Permissions -> Inline Policies -> Create Policy -> Custom Policy
+    - Policy Name: openshift (your preference)
+    - Policy Document:
 ```
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
cloudformation / iam are sufficient for the recent addition of cloudformation stacks.  However EC2 and Route53 access is still needed (it got removed somehow).  This one includes EC2FullAccess and Route53FullAccess policies inline as well.
